### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Documentation link:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds GitHub's Dependabot to keep dependencies up-to-date. There was no option to specify filename, so I assume [requirements.txt](https://github.com/JeffResc/sharkiq/blob/e091c36d91ca35d03202b9753defd9a51b861b71/requirements.txt) will be updated, but I am unsure about [requirements.test.txt](https://github.com/JeffResc/sharkiq/blob/e091c36d91ca35d03202b9753defd9a51b861b71/requirements.test.txt).