### PR TITLE
Bump actions/checkout to 2.4.0

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -19,7 +19,7 @@ jobs:
         python: [3.7, 3.8, 3.9]
     steps:
       - name: Checking out code from GitHub
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2.2.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2.4.0
     - name: Set up Python
       uses: actions/setup-python@v2.2.2
       with:


### PR DESCRIPTION
Bump [actions/checkout](https://github.com/actions/checkout) to version 2.4.0.