### PR TITLE
Fix crash for devices with no room support

### DIFF
--- a/sharkiq/sharkiq.py
+++ b/sharkiq/sharkiq.py
@@ -387,7 +387,10 @@ class SharkIqVacuum:
     def _get_device_room_list(self):
         """Gets the list of known rooms from the device, including the map identifier"""
         room_list = self.get_property_value(Properties.ROBOT_ROOM_LIST)
-        split = room_list.split(':')
+        if room_list:
+            split = room_list.split(':')
+        else:
+            split = ['rooms']
         return {
             # The room list is preceded by an identifier, which I believe identifies the list of rooms with the
             # onboard map in the robot


### PR DESCRIPTION
After a recent upgrade to homeassistant those of us with shark robots that don't support rooms have been getting crashes in this code. This fixes it for me at least.

https://github.com/home-assistant/core/issues/116670

Note that I don't have a vacuum with room support to test the opposite case. Probably want to test it with one before merging it.