### PR TITLE
Auth0 authentication

### DIFF
--- a/auth0demo.py
+++ b/auth0demo.py
@@ -1,0 +1,19 @@
+from sharkiq.auth0 import auth_flow_complete
+
+import asyncio
+import aiohttp
+
+async def main():
+    # Initialize the session
+    async with aiohttp.ClientSession() as session:
+        # Perform the authentication flow
+        # Change is_eu to True or False based on your region
+        try:
+            token = await auth_flow_complete(session, is_eu=True, username=input("Enter Shark Username: "), password=input("Enter Shark Password: "))
+            print("Authentication successful, token:", token)
+        except Exception as e:
+            print("Authentication failed:", str(e))
+
+if __name__ == "__main__":
+    asyncio.run(main())
+# This code snippet demonstrates how to use the auth_flow_complete function

--- a/sharkiq/auth0.py
+++ b/sharkiq/auth0.py
@@ -40,7 +40,7 @@ def generateURL(is_eu: bool, state: str, challenge: str):
     + '&code_challenge=' + urlEncode(challenge)
     + '&code_challenge_method=S256'
     + '&ui_locales=en'
-    + '&auth0Client=' + client)
+    + '&auth0Client=' + urlEncode(client))
 
 def generateRandomString(length):
     characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'

--- a/sharkiq/auth0.py
+++ b/sharkiq/auth0.py
@@ -28,7 +28,7 @@ def generateURL(is_eu: bool, state: str, challenge: str):
         redirect_uri = AUTH0_EU_REDIRECT_URI
         client = AUTH0_EU_CLIENT
     else:
-        url = AUTH0_DOMAIN
+        url = AUTH0_DOMAIN + '/authorize'
         client_id = AUTH0_CLIENT_ID
         redirect_uri = AUTH0_REDIRECT_URI
         client = AUTH0_CLIENT

--- a/sharkiq/auth0.py
+++ b/sharkiq/auth0.py
@@ -1,0 +1,186 @@
+"""Wrapper to authenticate with Shark IQ API."""
+
+import math
+import random
+import hashlib
+import codecs
+import base64
+import urllib.parse
+
+from aiohttp import ClientSession
+
+from .const import (
+    AUTH0_EU_REDIRECT_URI,
+    AUTH0_EU_DOMAIN,
+    AUTH0_EU_CLIENT_ID,
+    AUTH0_EU_CLIENT,
+    AUTH0_DOMAIN,
+    AUTH0_CLIENT_ID,
+    AUTH0_CLIENT,
+    AUTH0_REDIRECT_URI,
+    AUTH0_SCOPES
+)
+
+def generateURL(is_eu: bool, state: str, challenge: str):
+    if is_eu:
+        url = AUTH0_EU_DOMAIN
+        client_id = AUTH0_EU_CLIENT_ID
+        redirect_uri = AUTH0_EU_REDIRECT_URI
+        client = AUTH0_EU_CLIENT
+    else:
+        url = AUTH0_DOMAIN
+        client_id = AUTH0_CLIENT_ID
+        redirect_uri = AUTH0_REDIRECT_URI
+        client = AUTH0_CLIENT
+    return (url + "?response_type=code"
+    + '&client_id=' + urlEncode(client_id)
+    + '&state=' + urlEncode(state)
+    + '&scope=' + urlEncode(AUTH0_SCOPES)
+    + '&redirect_uri=' + urlEncode(redirect_uri)
+    + '&code_challenge=' + urlEncode(challenge)
+    + '&code_challenge_method=S256'
+    + '&ui_locales=en'
+    + '&auth0Client=' + client)
+
+def generateRandomString(length):
+    characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    result = ''
+    for _ in range(length):
+        randomIndex = math.floor(random.random() * len(characters))
+        result += characters[randomIndex]
+    return result
+
+def generateChallengeB64Hash(verification_code):
+    verification_encoded = codecs.encode(verification_code, 'utf-8')
+    verification_sha256 = hashlib.sha256(verification_encoded)
+    challenge_b64 = base64.b64encode(verification_sha256.digest()).decode()
+    challenge_b64_clean = challenge_b64.replace("+", "-").replace("/", "_").replace("=", "").replace("$", "")
+    return challenge_b64_clean
+
+def urlEncode(s):
+    return urllib.parse.quote_plus(s)
+
+def _extract_state_code(url: str) -> str:
+    """Extract the state code from the given URL."""
+    parsed_url = urllib.parse.urlparse(url)
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    code = query_params.get("state")
+    if not code:
+        raise ValueError("State not found in the URL")
+    return code[0]
+
+def _extract_callback_code(callback_url: str) -> str:
+    """Extract the callback code from the given URL."""
+    parsed_url = urllib.parse.urlparse(callback_url)
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    code = query_params.get("code")
+    if not code:
+        raise ValueError("Callback code not found in the URL")
+    return code[0]
+
+## Shark's implementation redirects to the signup page first, which is an odd choice
+
+async def _get_login_state(session: ClientSession, is_eu: bool, state: str, challenge: str) -> str:
+    """Retrieve the login state."""
+    async with session.get(generateURL(is_eu, state, challenge)) as response:
+        if response.status != 200:
+            raise Exception(f"Failed to get login state: {response.status}")
+        return _extract_state_code(str(response.url))
+
+async def _post_login(session: ClientSession, is_eu: bool,username: str, password: str, state: str):
+    """Post login"""
+    if is_eu:
+        login_url = AUTH0_EU_DOMAIN + "/u/login?ui_locales=en&state=" + state
+    else:
+        login_url = AUTH0_DOMAIN + "/u/login?ui_locales=en&state=" + state
+
+    async with session.post(
+        login_url,
+        data={
+            "username": username,
+            "password": password,
+            "action": "default",
+            "state": state,
+        },
+        allow_redirects=False,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Mobile Safari/537.36",
+            "sec-ch-ua": '"Not_A Brand";v="99", "Chromium";v="133", "Google Chrome";v="133"',
+            "sec-ch-ua-mobile": "?1",
+            "sec-ch-ua-platform": '"Android"',
+            "sec-fetch-dest": "document",
+            "sec-fetch-mode": "navigate",
+            "sec-fetch-site": "same-origin",
+            "sec-fetch-user": "?1",
+            "upgrade-insecure-requests": "1",
+            "content-type": "application/x-www-form-urlencoded",
+            "origin": AUTH0_EU_DOMAIN if is_eu else AUTH0_DOMAIN,
+            "referer": login_url,
+        }
+    ) as response:
+        if response.status != 302:
+            raise Exception(f"Failed to post login: {response.status}")
+        location = response.headers.get("Location")
+        if "/u/login" in location:
+            raise Exception("Invalid username or password")
+        if not location:
+            raise Exception("No Location header found in response")
+        return location
+
+async def _resume_authorization(session: ClientSession, is_eu: bool, resume_location: str):
+    """Resume the authorization process."""
+    if is_eu:
+        resume_url = AUTH0_EU_DOMAIN + resume_location
+    else:
+        resume_url = AUTH0_DOMAIN + resume_location
+    async with session.get(resume_url, allow_redirects=False) as response:
+        if response.status != 302:
+            raise Exception(f"Failed to resume authorization: {response.status}")
+        location = response.headers.get("Location")
+        if "com.sharkninja.shark" not in location:
+            raise Exception("Invalid redirect location")
+        return location
+
+async def _get_token(session: ClientSession, is_eu: bool, code: str, verifier: str):
+    """Get the token using the code."""
+    if is_eu:
+        token_url = AUTH0_EU_DOMAIN + "/oauth/token"
+    else:
+        token_url = AUTH0_DOMAIN + "/oauth/token"
+    async with session.post(
+        token_url,
+        json={
+            "client_id": AUTH0_EU_CLIENT_ID,
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": AUTH0_EU_REDIRECT_URI,
+            "code_verifier": verifier,
+        },
+        allow_redirects=False
+    ) as response:
+        if response.status != 200:
+            raise Exception(f"Failed to get token: {response.status}")
+        return await response.json()
+
+async def auth_flow_complete(session: ClientSession, is_eu: bool, username: str, password: str):
+    """Complete the authentication flow."""
+    state = generateRandomString(43)
+    verification = generateRandomString(43)
+    challenge = generateChallengeB64Hash(verification)
+
+    # Step 1: Get login state
+    login_state = await _get_login_state(session, is_eu, state, challenge)
+
+    # Step 2: Post login
+    resume_location = await _post_login(session, is_eu, username, password, login_state)
+
+    # Step 3: Resume Authorization
+    resume_location = await _resume_authorization(session, is_eu, resume_location)
+
+    # Step 4: Extract callback code
+    code = _extract_callback_code(resume_location)
+
+    # Step 5: Get token
+    token_response = await _get_token(session, is_eu, code, verification)
+    
+    return token_response

--- a/sharkiq/const.py
+++ b/sharkiq/const.py
@@ -9,3 +9,14 @@ EU_LOGIN_URL = "https://user-field-eu.aylanetworks.com"
 EU_SHARK_APP_ID = "Shark-Android-EUField-Fw-id"
 EU_SHARK_APP_SECRET = "Shark-Android-EUField-s-zTykblGJujGcSSTaJaeE4PESI"
 
+AUTH0_EU_DOMAIN = "https://logineu.sharkninja.com"
+AUTH0_EU_CLIENT_ID = "rKDx9O18dBrY3eoJMTkRiBZHDvd9Mx1I"
+AUTH0_EU_CLIENT = "eyJuYW1lIjoiQXV0aDAuQW5kcm9pZCIsImVudiI6eyJhbmRyb2lkIjoiMzQifSwidmVyc2lvbiI6IjIuOS4wIn0="
+AUTH0_EU_REDIRECT_URI = "com.sharkninja.shark://logineu.sharkninja.com/android/com.sharkninja.shark/callback"
+
+AUTH0_DOMAIN = "https://login.sharkninja.com"
+AUTH0_CLIENT_ID = "wsguxrqm77mq4LtrTrwg8ZJUxmSrexGi"
+AUTH0_CLIENT = "eyJ2ZXJzaW9uIjoiMi42LjAiLCJuYW1lIjoiQXV0aDAuc3dpZnQiLCJlbnI6eyJpVCI6IjE3LjYiLCJzd2lmdCI6IjUueCJ9fQ=="
+AUTH0_REDIRECT_URI = "com.sharkninja.shark://login.sharkninja.com/ios/com.sharkninja.shark/callback"
+
+AUTH0_SCOPES = "openid profile email offline_access read:users read:current_user read:user_idp_tokens"


### PR DESCRIPTION
Ok, this is nasty in its current state, things are all over the place, but it does work. I'm not expecting this to be merged like this at all. However..

As this has been broken for a few months I thought I would take a first attempt at resolving this, OAuth flows aren't too difficult to "spoof" once you get an understanding whats going on.

Shark has 2 sets of Auth0 environments (including Client IDs, Auth0 Clients, secrets etc.) as expected for EU/non-EU customers. As I'm in the EU I've only been able to successfully test any of this with the EU endpoints.

The auth flow is as follows:

1. Send GET request to `/authorize` endpoint. This is a 302 redirect back to `/u/signup` - very odd choice here to go straight to a sign up flow, but nevermind.
2. Very important we store and use the `state` parameter throughout the whole transaction, basically it tracks whos request is what.
3. User clicks login, taken to `/u/login....`
4. Basic POST request with the username, password and state to that same endpoint, if successful it will redirect us to `/authorize/resume`
5. `/authorize/resume` will then redirect us to the original redirect URL `
com.sharkninja.shark://logineu.sharkninja.com....`

I'm not 100% sure if all the headers are needed in the `_post_login` function at this point... In theory not, but then again you can do some pretty complex filtering and restrictions with Auth0 and without at least most of these, on step 4 it would just redirect us back to `/u/login`

I've created a little `auth0demo.py` file that just demonstrates the basic capability of this.

Also, sorry for the mess! Late here and personally I'd really like to get my shark up and running in Home Assistant ;)