### PR TITLE
Add Python version `3.11`, `3.12` and `3.13` to code coverage reports

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checking out code from GitHub
         uses: actions/checkout@v2.4.0
@@ -33,7 +33,7 @@ jobs:
       - name: Pytest with coverage reporting
         run: pytest --cov=sharkiq --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.python-version == 3.9 && matrix.os == 'ubuntu'
+        if: matrix.python-version == 3.13 && matrix.os == 'ubuntu'
         uses: codecov/codecov-action@v1.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Add Python version `3.11`, `3.12` and `3.13` to code coverage reports. Remove versions `3.7` and `3.8`.