### PR TITLE
Add support for Auth0 refresh token

### DIFF
--- a/tests/test_ayla_api.py
+++ b/tests/test_ayla_api.py
@@ -68,7 +68,7 @@ class TestAylaApi:
             "password": "mypassword",
             "scope": "openid profile email offline_access"
         }
-        assert dummy_api._auth0_refresh_login_data == {
+        assert dummy_api._auth0_refresh_data == {
             "grant_type": "refresh_token",
             "client_id": AUTH0_CLIENT_ID,
             "refresh_token": "refresh_token_123",

--- a/tests/test_ayla_api.py
+++ b/tests/test_ayla_api.py
@@ -13,10 +13,11 @@ from datetime import datetime, timedelta
 
 
 def test_get_ayla_api():
-    api = get_ayla_api("myusername@mysite.com", "mypassword")
+    api = get_ayla_api("myusername@mysite.com", "mypassword", "refresh_token_123")
 
     assert api._email == "myusername@mysite.com"
     assert api._password == "mypassword"
+    assert api.auth0_refresh_token == "refresh_token_123"
     assert api._access_token is None
     assert api._refresh_token is None
     assert api._auth_expiration is None
@@ -41,6 +42,7 @@ class TestAylaApi:
         assert api._app_id == "app_id_123"
         assert api._app_secret == "appsecret_123"
         assert api._auth0_client_id == "client_id_123"
+        assert api.auth0_refresh_token is None
         assert api.websession is None
 
     @pytest.mark.asyncio
@@ -65,6 +67,11 @@ class TestAylaApi:
             "username": "myusername@mysite.com",
             "password": "mypassword",
             "scope": "openid profile email offline_access"
+        }
+        assert dummy_api._auth0_refresh_login_data == {
+            "grant_type": "refresh_token",
+            "client_id": AUTH0_CLIENT_ID,
+            "refresh_token": "refresh_token_123",
         }
 
     def test_set_id_token__401_requires_verification_response(self, dummy_api):

--- a/tests/test_ayla_api.py
+++ b/tests/test_ayla_api.py
@@ -68,6 +68,11 @@ class TestAylaApi:
             "password": "mypassword",
             "scope": "openid profile email offline_access"
         }
+
+    def test_auth0__refresh_data(self, dummy_api):
+        assert dummy_api.auth0_refresh_token == None
+        assert dummy_api._auth0_refresh_data == None
+        dummy_api.auth0_refresh_token = "refresh_token_123"
         assert dummy_api._auth0_refresh_data == {
             "grant_type": "refresh_token",
             "client_id": AUTH0_CLIENT_ID,


### PR DESCRIPTION
Implement functionality to utilize Auth0 refresh tokens for improved authentication flow.

This change enhances authentication by allowing token refresh capabilities within the auth0 flow (https://auth0.com/docs/secure/tokens/refresh-tokens/use-refresh-tokens)

In theory this might lower the occurance of reported issues such as:
https://github.com/JeffResc/sharkiq/issues/73
https://github.com/home-assistant/core/issues/142890

Because we will no longer need to pass the username and password on every sign in instance. Instead the refresh token can be stored in the Home Assistant config and going forward the module can use that to authenticate with Auth0.

I've tested this locally and works (although I don't have any of the same reported issues).

This change however would require changes to the Home Assistant config flow to take full advantage.

Note, refresh tokens only last 24 hours, so the Home Assistant integration will need to update this in its own config.